### PR TITLE
fix: Don't sent api request if chat only local

### DIFF
--- a/frontend/app/sidebar/chatHistory.tsx
+++ b/frontend/app/sidebar/chatHistory.tsx
@@ -45,10 +45,12 @@ export function ChatEntry({ selected, chat }: ChatEntryProps) {
   }
   function deleteChat() {
     dispatch({ type: "delete-chat", uuid: chat.uuid });
-    deleteChatEndpoint(chat).catch(() => {
-      showError("Failed to delete chat remotely, please try again later!");
-      dispatch({ type: "update-chat", chat: chat });
-    });
+    if (chat.status !== "created") {
+      deleteChatEndpoint(chat).catch(() => {
+        showError("Failed to delete chat remotely, please try again later!");
+        dispatch({ type: "update-chat", chat: chat });
+      });
+    }
   }
 
   const bar = (


### PR DESCRIPTION
Fixes an issue where deleting a chat which was not on the backend would cause the backend request to fail as the chat doesn't exist on the backend.

Just waiting on the fixed compose to be pushed first as to not to cause merge conflicts